### PR TITLE
chore: Overwrite JitPack dependencies in PRs

### DIFF
--- a/.github/workflows/yaks-tests.yaml
+++ b/.github/workflows/yaks-tests.yaml
@@ -54,6 +54,15 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
+    - name: Set JitPack coordinates for pull requests
+      if: github.event_name == 'pull_request'
+      env:
+        BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}
+      run: |
+        echo "Set JitPack dependency coordinates to ${BASE_REPO}:${{ github.head_ref }}-SNAPSHOT"
+
+        # Overwrite JitPack coordinates in the local Kamelets so the tests can use the utility classes in this PR
+        find kamelets -maxdepth 1 -name '*.kamelet.yaml' -exec sed  -i "s/github:apache.camel-kamelets:camel-kamelets-utils:${{ github.base_ref }}-SNAPSHOT/github:${BASE_REPO/\//.}:camel-kamelets-utils:${{ github.head_ref }}-SNAPSHOT/g" {} +
     - name: Get Camel K CLI
       run: |
         curl --fail -L --silent https://github.com/apache/camel-k/releases/download/v${CAMEL_K_VERSION}/camel-k-client-${CAMEL_K_VERSION}-linux-64bit.tar.gz -o kamel.tar.gz
@@ -89,6 +98,7 @@ jobs:
         # TODO replaces the below statement with --operator-env-vars KAMEL_INSTALL_DEFAULT_KAMELETS=false
         # when we use camel k 1.8.0
         kubectl delete kamelets --all
+
         # Install the local kamelets
         find kamelets -maxdepth 1 -name '*.kamelet.yaml' -exec kubectl apply -f {} \;
     - name: Install YAKS


### PR DESCRIPTION
This change in GitHub workflow definition enables PRs to use new/changed utility classes in module camel-kamelets-utils. The workflow overwrites the JitPack dependency coordinates in all Kamelets to point to the actual PR base branch instead of main-SNAPSHOT. This ensures that the automated tests use the utility classes from that PR base branch instead of main-SNAPSHOT. So PRs will be able to have a green GitHub CI workflow even if main-SNAPSHOT is not aware of the utility class at the moment.