### PR TITLE
chore: Add forcePathStyle option to aws-s3 Kamelets

### DIFF
--- a/.github/workflows/yaks-tests.yaml
+++ b/.github/workflows/yaks-tests.yaml
@@ -42,7 +42,7 @@ concurrency:
 
 env:
   YAKS_VERSION: 0.14.2
-  YAKS_RUN_OPTIONS: "--timeout=15m --local -e YAKS_CAMELK_MAX_ATTEMPTS=10 -e YAKS_JBANG_CAMEL_VERSION=4.0.0-M1 -e YAKS_JBANG_KAMELETS_LOCAL_DIR=../../../kamelets"
+  YAKS_RUN_OPTIONS: "--timeout=15m --local -e YAKS_CAMELK_MAX_ATTEMPTS=10 -e YAKS_JBANG_CAMEL_VERSION=4.0.0-M3 -e YAKS_JBANG_KAMELETS_LOCAL_DIR=../../../kamelets"
 
 jobs:
   test:

--- a/kamelets/aws-s3-sink.kamelet.yaml
+++ b/kamelets/aws-s3-sink.kamelet.yaml
@@ -96,6 +96,13 @@ spec:
         x-descriptors:
           - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
+      forcePathStyle:
+        title: Force Path Style
+        description: Forces path style when accessing AWS S3 buckets.
+        type: boolean
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+        default: false
       keyName:
         title: Key Name
         description: The key name for saving an element in the bucket.
@@ -113,7 +120,7 @@ spec:
           when:
             - simple: '${propertiesExist:!keyName}'
               steps:
-                - choice:   
+                - choice:
                     when:
                       - simple: "${header[file]}"
                         steps:
@@ -140,4 +147,5 @@ spec:
             useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
             uriEndpointOverride: "{{?uriEndpointOverride}}"
             overrideEndpoint: "{{overrideEndpoint}}"
+            forcePathStyle: "{{forcePathStyle}}"
             keyName: "{{?keyName}}"

--- a/kamelets/aws-s3-source.kamelet.yaml
+++ b/kamelets/aws-s3-source.kamelet.yaml
@@ -96,6 +96,13 @@ spec:
         x-descriptors:
           - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
+      forcePathStyle:
+        title: Force Path Style
+        description: Forces path style when accessing AWS S3 buckets.
+        type: boolean
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+        default: false
       delay:
         title: Delay
         description: The number of milliseconds before the next poll of the selected bucket.
@@ -128,6 +135,7 @@ spec:
         useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
         uriEndpointOverride: "{{?uriEndpointOverride}}"
         overrideEndpoint: "{{overrideEndpoint}}"
+        forcePathStyle: "{{forcePathStyle}}"
         delay: "{{delay}}"
       steps:
       - process:

--- a/kamelets/aws-s3-streaming-upload-sink.kamelet.yaml
+++ b/kamelets/aws-s3-streaming-upload-sink.kamelet.yaml
@@ -99,7 +99,7 @@ spec:
         description: The naming strategy to use in streaming upload mode. There are 2 enums and the value can be one of progressive, random
         type: string
         default: "progressive"
-      keyName: 
+      keyName:
         title: Key Name
         description: Setting the key name for an element in the bucket through endpoint parameter. In Streaming Upload, with the default configuration, this will be the base for the progressive creation of files.
         type: string
@@ -117,6 +117,13 @@ spec:
       overrideEndpoint:
         title: Endpoint Overwrite
         description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
+        type: boolean
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+        default: false
+      forcePathStyle:
+        title: Force Path Style
+        description: Forces path style when accessing AWS S3 buckets.
         type: boolean
         x-descriptors:
           - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
@@ -145,3 +152,4 @@ spec:
             useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
             uriEndpointOverride: "{{?uriEndpointOverride}}"
             overrideEndpoint: "{{overrideEndpoint}}"
+            forcePathStyle: "{{forcePathStyle}}"

--- a/kamelets/data-type-action.kamelet.yaml
+++ b/kamelets/data-type-action.kamelet.yaml
@@ -44,7 +44,7 @@ spec:
         example: "camel"
       format:
         title: Data Type Format
-        description: Defines the data type that will be applied by this action. The Kameelet catalog supports different data types and performs automatic message conversion according to the given type.
+        description: Defines the data type that will be applied by this action. The Kamelet catalog supports different data types and performs automatic message conversion according to the given type.
         type: string
   dependencies:
     - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-s3-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-s3-sink.kamelet.yaml
@@ -96,6 +96,13 @@ spec:
         x-descriptors:
           - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
+      forcePathStyle:
+        title: Force Path Style
+        description: Forces path style when accessing AWS S3 buckets.
+        type: boolean
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+        default: false
       keyName:
         title: Key Name
         description: The key name for saving an element in the bucket.
@@ -113,7 +120,7 @@ spec:
           when:
             - simple: '${propertiesExist:!keyName}'
               steps:
-                - choice:   
+                - choice:
                     when:
                       - simple: "${header[file]}"
                         steps:
@@ -140,4 +147,5 @@ spec:
             useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
             uriEndpointOverride: "{{?uriEndpointOverride}}"
             overrideEndpoint: "{{overrideEndpoint}}"
+            forcePathStyle: "{{forcePathStyle}}"
             keyName: "{{?keyName}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-s3-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-s3-source.kamelet.yaml
@@ -96,6 +96,13 @@ spec:
         x-descriptors:
           - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
+      forcePathStyle:
+        title: Force Path Style
+        description: Forces path style when accessing AWS S3 buckets.
+        type: boolean
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+        default: false
       delay:
         title: Delay
         description: The number of milliseconds before the next poll of the selected bucket.
@@ -128,6 +135,7 @@ spec:
         useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
         uriEndpointOverride: "{{?uriEndpointOverride}}"
         overrideEndpoint: "{{overrideEndpoint}}"
+        forcePathStyle: "{{forcePathStyle}}"
         delay: "{{delay}}"
       steps:
       - process:

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-s3-streaming-upload-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-s3-streaming-upload-sink.kamelet.yaml
@@ -99,7 +99,7 @@ spec:
         description: The naming strategy to use in streaming upload mode. There are 2 enums and the value can be one of progressive, random
         type: string
         default: "progressive"
-      keyName: 
+      keyName:
         title: Key Name
         description: Setting the key name for an element in the bucket through endpoint parameter. In Streaming Upload, with the default configuration, this will be the base for the progressive creation of files.
         type: string
@@ -117,6 +117,13 @@ spec:
       overrideEndpoint:
         title: Endpoint Overwrite
         description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
+        type: boolean
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+        default: false
+      forcePathStyle:
+        title: Force Path Style
+        description: Forces path style when accessing AWS S3 buckets.
         type: boolean
         x-descriptors:
           - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
@@ -145,3 +152,4 @@ spec:
             useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
             uriEndpointOverride: "{{?uriEndpointOverride}}"
             overrideEndpoint: "{{overrideEndpoint}}"
+            forcePathStyle: "{{forcePathStyle}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/data-type-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/data-type-action.kamelet.yaml
@@ -44,7 +44,7 @@ spec:
         example: "camel"
       format:
         title: Data Type Format
-        description: Defines the data type that will be applied by this action. The Kameelet catalog supports different data types and performs automatic message conversion according to the given type.
+        description: Defines the data type that will be applied by this action. The Kamelet catalog supports different data types and performs automatic message conversion according to the given type.
         type: string
   dependencies:
     - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"

--- a/test/aws-s3/aws-s3-to-http.yaml
+++ b/test/aws-s3/aws-s3-to-http.yaml
@@ -28,6 +28,7 @@ spec:
     properties:
       bucketNameOrArn: ${aws.s3.bucketNameOrArn}
       overrideEndpoint: true
+      forcePathStyle: false
       uriEndpointOverride: ${YAKS_TESTCONTAINERS_LOCALSTACK_S3_URL}
       accessKey: ${YAKS_TESTCONTAINERS_LOCALSTACK_ACCESS_KEY}
       secretKey: ${YAKS_TESTCONTAINERS_LOCALSTACK_SECRET_KEY}

--- a/test/aws-s3/aws-s3-to-knative-broker.yaml
+++ b/test/aws-s3/aws-s3-to-knative-broker.yaml
@@ -28,6 +28,7 @@ spec:
     properties:
       bucketNameOrArn: ${aws.s3.bucketNameOrArn}
       overrideEndpoint: true
+      forcePathStyle: true
       uriEndpointOverride: ${YAKS_TESTCONTAINERS_LOCALSTACK_S3_URL}
       accessKey: ${YAKS_TESTCONTAINERS_LOCALSTACK_ACCESS_KEY}
       secretKey: ${YAKS_TESTCONTAINERS_LOCALSTACK_SECRET_KEY}

--- a/test/aws-s3/aws-s3-to-knative-channel.yaml
+++ b/test/aws-s3/aws-s3-to-knative-channel.yaml
@@ -28,6 +28,7 @@ spec:
     properties:
       bucketNameOrArn: ${aws.s3.bucketNameOrArn}
       overrideEndpoint: true
+      forcePathStyle: true
       uriEndpointOverride: ${YAKS_TESTCONTAINERS_LOCALSTACK_S3_URL}
       accessKey: ${YAKS_TESTCONTAINERS_LOCALSTACK_ACCESS_KEY}
       secretKey: ${YAKS_TESTCONTAINERS_LOCALSTACK_SECRET_KEY}

--- a/test/aws-s3/aws-s3-uri-binding.yaml
+++ b/test/aws-s3/aws-s3-uri-binding.yaml
@@ -28,6 +28,7 @@ spec:
     properties:
       bucketNameOrArn: ${aws.s3.bucketNameOrArn}
       overrideEndpoint: true
+      forcePathStyle: false
       uriEndpointOverride: ${YAKS_TESTCONTAINERS_LOCALSTACK_S3_URL}
       accessKey: ${YAKS_TESTCONTAINERS_LOCALSTACK_ACCESS_KEY}
       secretKey: ${YAKS_TESTCONTAINERS_LOCALSTACK_SECRET_KEY}


### PR DESCRIPTION
chore: Add forcePathStyle option to aws-s3 Kamelets

- Since Apache Camel 4 the aws-s3 component supports to force the path style when accessing buckets on AWS S3
- Path style access is essential when testing with local AWS S3 instances such as LocalStack