### PR TITLE
Add Makefile to run YAKS tests

### DIFF
--- a/.github/workflows/yaks-tests.yaml
+++ b/.github/workflows/yaks-tests.yaml
@@ -42,7 +42,6 @@ concurrency:
 
 env:
   YAKS_VERSION: 0.16.0
-  YAKS_RUN_OPTIONS: "--timeout=15m --local -e YAKS_CAMELK_MAX_ATTEMPTS=10 -e YAKS_JBANG_CAMEL_VERSION=4.0.0 -e YAKS_JBANG_KAMELETS_VERSION=4.0.0-SNAPSHOT -e YAKS_JBANG_KAMELETS_LOCAL_DIR=../../../kamelets -e YAKS_KAMELET_API_VERSION=v1alpha1"
 
 jobs:
   test:
@@ -88,22 +87,8 @@ jobs:
         
         echo "Running YAKS tests for Kamelets"
         
-        yaks run test/aws-ddb-sink $YAKS_RUN_OPTIONS
-        yaks run test/aws-s3 $YAKS_RUN_OPTIONS
-        
-        yaks run test/avro-data-type $YAKS_RUN_OPTIONS
-        yaks run test/avro-serdes-action $YAKS_RUN_OPTIONS
-        
-        yaks run test/extract-field-action $YAKS_RUN_OPTIONS
-        yaks run test/insert-field-action $YAKS_RUN_OPTIONS
-        
-        yaks run test/mail-sink $YAKS_RUN_OPTIONS
-        yaks run test/timer-source $YAKS_RUN_OPTIONS
-        yaks run test/timer-to-http $YAKS_RUN_OPTIONS
-        yaks run test/data-type-action $YAKS_RUN_OPTIONS
-        yaks run test/earthquake-source $YAKS_RUN_OPTIONS
-        yaks run test/rest-openapi-sink $YAKS_RUN_OPTIONS
-        yaks run test/kafka $YAKS_RUN_OPTIONS
+        cd test 
+        make yaks
     - uses: actions/upload-artifact@v3
       if: failure()
       with:

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+camel-version := 4.0.0
+camel-kamelets-version := 4.0.0-SNAPSHOT
+kamelet-api-version := v1alpha1
+kamelets-local-dir := ../../../kamelets
+test := .
+
+YAKS_RUN_OPTIONS := --timeout=15m --local -e YAKS_CAMELK_MAX_ATTEMPTS=10 -e YAKS_JBANG_CAMEL_VERSION=$(camel-version) -e YAKS_JBANG_KAMELETS_VERSION=$(camel-kamelets-version) -e YAKS_JBANG_KAMELETS_LOCAL_DIR=$(kamelets-local-dir) -e YAKS_KAMELET_API_VERSION=$(kamelet-api-version)
+
+default: all
+
+check-setup:
+	@java -version
+	@jbang version
+	@yaks version
+	@jbang camel@apache/camel --version
+	@echo "Test setup - OK"
+
+all: check-setup
+	@echo "Running YAKS tests"
+	@echo #
+	yaks run . $(YAKS_RUN_OPTIONS)
+
+yaks: check-setup
+	@echo "Running YAKS test"
+	@echo #
+	yaks run $(test) $(YAKS_RUN_OPTIONS)
+
+.PHONY: all, yaks

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,27 @@
+# Kamelets YAKS Tests
+
+This folder contains a suite of integration tests for Kamelets
+
+You need the following tools to run the tests:
+- Java 17
+- [JBang](https://www.jbang.dev/)
+- [Camel JBang](https://camel.apache.org/manual/camel-jbang.html)
+- [YAKS](https://github.com/citrusframework/yaks)
+
+Once everything is set you just need to run
+
+```console
+  make yaks
+```
+
+This runs all available YAKS tests that are not marked as `@ignored`.
+
+You can run individual tests when specifying its folder or feature file name.
+
+```console
+  make yaks test=timer-source/timer-source.feature
+```
+
+The Makefile is a wrapper for the YAKS binary which is able to run the BDD Gherkin feature files. 
+You can also run YAKS tooling directly form your local machine.
+By default, the YAKS tests use local runtime where Camel integrations, Kamelets, bindings and pipes are run with Camel JBang.

--- a/test/avro-data-type/yaks-config.yaml
+++ b/test/avro-data-type/yaks-config.yaml
@@ -20,10 +20,6 @@ config:
     temporary: false
   runtime:
     env:
-      - name: YAKS_JBANG_KAMELETS_LOCAL_DIR
-        value: "../../../kamelets"
-      - name: YAKS_CAMELK_KAMELET_API_VERSION
-        value: v1
       - name: YAKS_CAMELK_AUTO_REMOVE_RESOURCES
         value: false
       - name: YAKS_KUBERNETES_AUTO_REMOVE_RESOURCES

--- a/test/avro-serdes-action/yaks-config.yaml
+++ b/test/avro-serdes-action/yaks-config.yaml
@@ -20,10 +20,6 @@ config:
     temporary: false
   runtime:
     env:
-      - name: YAKS_JBANG_KAMELETS_LOCAL_DIR
-        value: "../../../kamelets"
-      - name: YAKS_CAMELK_KAMELET_API_VERSION
-        value: v1
       - name: YAKS_CAMELK_AUTO_REMOVE_RESOURCES
         value: false
       - name: YAKS_KUBERNETES_AUTO_REMOVE_RESOURCES

--- a/test/salesforce-sink/salesforce-sink.feature
+++ b/test/salesforce-sink/salesforce-sink.feature
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ---------------------------------------------------------------------------
-
+@ignored
 Feature: Salesforce Kamelet
 
   Background:
@@ -70,7 +70,6 @@ Feature: Salesforce Kamelet
     When send GET /services/data/v50.0/query/
     Then verify HTTP response expression: $.totalSize="0"
     And receive HTTP 200 OK
-
 
   Scenario: Remove Camel-K resources
     Given delete KameletBinding timer-to-salesforce-binding

--- a/test/salesforce-sink/yaks-config.yaml
+++ b/test/salesforce-sink/yaks-config.yaml
@@ -26,6 +26,9 @@ config:
         value: false
       - name: YAKS_JBANG_CAMEL_DUMP_INTEGRATION_OUTPUT
         value: true
+    cucumber:
+      tags:
+        - "not @ignored"
     settings:
       loggers:
         - name: INTEGRATION_STATUS


### PR DESCRIPTION
- Adding Makefile as a wrapper for the YAKS binary
- Makes local YAKS test execution more comfortable
- Automatically set YAKS runtime options such as Camel JBang version or local Kamelets directory
- Use the Makefile in GitHub actions CI to run all YAKS tests